### PR TITLE
Short-term fix: Have websocket connection manager check if websocket is disconnected before sending messages

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -121,7 +121,7 @@ class ConnectionManager:
         self.active_connections: List[WebSocket] = []
 
     async def connect(self, websocket: WebSocket):
-        LOG.info('!!! Websocket connect: {}.'.format(websocket.user))
+        LOG.info('!!! Websocket connect: {}.'.format(websocket))
         await websocket.accept()
         self.active_connections.append(websocket)
 


### PR DESCRIPTION
Problem: Upon browser refresh, the websocket connection manager is not purging disconnected websockets from the active_connections list before broadcasting again.

Temp fix: Added if/else check in the api/main.py to have the connection manager object skip websockets with WebSocketState.DISCONNECTED so that it doesn't crash rabbit. Also upped the details in the LOG.info messages accompanying websocket connection/disconnection. Further: removed extraneous yield statement in the mq_channel() function that's part of closing rabbit connections and replaced it with a simple return.

NOTE: Long-term this should probably be changed to use a dict or something else more robust.