### PR TITLE
Convert dungeon master process to a true container

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -60,3 +60,24 @@ services:
       interval: 10s
       retries: 3
       timeout: 30s
+
+  dm:
+    build:
+      context: .
+      dockerfile: containers/dm/Dockerfile
+    # restart: always
+    volumes: 
+      - ./:/code
+    environment:
+      MONGO_USER: $MONGO_USER
+      MONGO_PASSWORD: $MONGO_PASSWORD
+      MONGO_HOST: $MONGO_HOST
+      MONGO_PORT: $MONGO_PORT
+      API_ORIGINS: $API_ORIGINS
+      RABBIT_USER: $RABBIT_USER
+      RABBIT_PASSWORD: $RABBIT_PASSWORD
+      RABBIT_HOST: $RABBIT_HOST
+    depends_on:
+      rabbit:
+        condition: service_healthy
+        restart: true

--- a/containers/dm/Dockerfile
+++ b/containers/dm/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12
+
+WORKDIR /code
+
+VOLUME /code
+
+# for the moment we're voluming the whole repo so put the container specific file in /tmp
+COPY containers/dm/requirements.txt /tmp/requirements.txt
+
+# strictly speaking this isn't needed yet since it will be inherited from the volume
+#COPY $SETTINGS_FILE .env 
+
+RUN pip install --no-cache-dir --upgrade -r /tmp/requirements.txt
+
+CMD ["python", "demoloop.py"]

--- a/containers/dm/requirements.txt
+++ b/containers/dm/requirements.txt
@@ -1,0 +1,5 @@
+schema
+pymongo
+pyyaml
+pika
+pydantic-settings

--- a/demoloop.py
+++ b/demoloop.py
@@ -38,10 +38,11 @@ if __name__ == "__main__":
     random.seed(seed)
 
     settings = Settings()
-    mongo_client = MongoService('mongodb://{}:{}@localhost:{}'.format(settings.mongo_user, settings.mongo_password, settings.mongo_port))
+    mongo_client = MongoService('mongodb://{}:{}@{}:{}'.format(settings.mongo_user, settings.mongo_password, settings.mongo_host, settings.mongo_port))
 
     creds = pika.PlainCredentials(settings.rabbit_user, settings.rabbit_password)
-    parameters = (pika.ConnectionParameters(host='localhost', credentials=creds))
+    parameters = (pika.ConnectionParameters(host=settings.rabbit_host, credentials=creds))
+    print(parameters)
     connection = pika.BlockingConnection(parameters)
     channel = connection.channel()
     channel.exchange_declare('dungeon', exchange_type='fanout', durable=True)

--- a/dev.env
+++ b/dev.env
@@ -14,3 +14,5 @@ RABBIT_HOST=rabbit
 # For development the external web port can just be 80, though feel
 # free to override if its already spoken for on the host machine
 EXTERNAL_WEB_PORT=80
+
+SETTINGS_FILE=dev.env

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+# The DM service has been moved to it's own container but this is the requirements file for running it yourself
+# if you want to do it locally
+
 # Using schema for basic YAML validation. Its just for ease of finding mistakes, so we don't want anything heavier
 schema
 pymongo


### PR DESCRIPTION
Previously the DM process was intended to run locally to better isolate its excessive output but its finally time to promote to a container so everything can be ready for a production-like infrastructure.